### PR TITLE
update log4j version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <jetty.version>9.4.43.v20210629</jetty.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
-    <log4j.version>2.14.1</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <mockito.version>3.12.4</mockito.version>
     <picocli.version>4.6.1</picocli.version>
     <resteasy.version>4.7.1.Final</resteasy.version>


### PR DESCRIPTION
PR to fix log4shell-vulnerability